### PR TITLE
Fixes #33 - Increase width to fix scrolling issue

### DIFF
--- a/src/components/Chunk.js
+++ b/src/components/Chunk.js
@@ -32,7 +32,7 @@ const Popover = styled.div`
     --offset: 5rem;
 
     top: initial;
-    width: 370px;
+    width: 450px;
 
     ${({ orientation }) => {
       switch (orientation) {


### PR DESCRIPTION
The Port text is long enough to require the user to scroll. 
By increasing the width from 370px to 450px, this fixes the problem.

Close #33 